### PR TITLE
shorthand obj, react "children" prop

### DIFF
--- a/rules/es6.js
+++ b/rules/es6.js
@@ -111,7 +111,7 @@ module.exports = {
 
 		// require method and property shorthand syntax for object literals
 		// http://eslint.org/docs/rules/object-shorthand
-		"object-shorthand": [2, "consistent"],
+		"object-shorthand": [2, "always"],
 
 		// suggest using arrow functions as callbacks
 		// TODO replace all anoninumous functions callback with arrow-callback

--- a/rules/react.js
+++ b/rules/react.js
@@ -162,7 +162,7 @@ module.exports = {
 
 		// Prevent missing props validation in a React component definition
 		// https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/prop-types.md
-		"react/prop-types": [2, {ignore: [], customValidators: []}],
+		"react/prop-types": [2, {ignore: ["children"], customValidators: []}],
 
 		// Prevent missing React when using JSX
 		// https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/react-in-jsx-scope.md


### PR DESCRIPTION
- enforce shorthand object props
- ignore 'children' prop as it's reserved prop for React children elements and shouldn't be validated
